### PR TITLE
Generalize performing stuff before retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["rust-patterns"]
 keywords = ["tokio", "futures", "retry"]
 
 [dependencies]
-tokio = { version = "0.2", default-features = false, features = ["time", "macros", "test-util", "rt-core"] }
+tokio = { version = "0.2", default-features = false, features = ["time", "macros", "test-util", "rt-core", "sync"] }
 futures = "0.3"
-log = "0.4"
 pin-project = "1"


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/tryhard/issues/2

This replaces the logging with a general way allowing users to perform stuff before retries.

Example that prints and gathers errors:

```rust
use std::sync::Arc;
use tokio::sync::Mutex;

let all_errors = Arc::new(Mutex::new(Vec::new()));

tryhard::retry_fn(|| async {
    // just some dummy computation that always fails
    Err::<(), _>("fail")
})
    .retries(10)
    .on_retry(|_attempt: u32, _next_delay: Option<Duration>, error: &String| {
        // the future must be `'static` so it cannot contain references
        let all_errors = Arc::clone(&all_errors);
        let error = error.clone();
        async move {
            eprintln!("Something failed: {}", error);
            all_errors.lock().await.push(error);
        }
    })
    .await
    .unwrap_err();

assert_eq!(all_errors.lock().await.len(), 10);
```