### PR TITLE
Switch to tokio 0.3 and make 0.2 opt-in

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,16 +48,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fetch
-      - name: cargo test build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --tests --release
-      - name: cargo test
+      - name: cargo test (tokio 0.3)
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release
+      - name: cargo test (tokio 0.2)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features tokio-02
 
   publish-check:
     name: Publish Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- N/A
+
+### Changed
+- Changed from using Tokio 0.2 by default to using Tokio 0.3. You can switch back to Tokio 0.2 by declaring your dependency with `tryhard = { version = "your-version", default-features = false, features = ["tokio-02"] }`.
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- N/A
+
+### Security
+- N/A
 
 ## [0.1.0] - 2020-11-14
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,22 @@ categories = ["rust-patterns"]
 keywords = ["tokio", "futures", "retry"]
 
 [dependencies]
-tokio = { version = "0.2", default-features = false, features = ["time", "macros", "test-util", "rt-core", "sync"] }
 futures = "0.3"
 pin-project = "1"
+
+[dependencies.tokio-03]
+package = "tokio"
+version = "0.3"
+default-features = false
+features = ["rt", "time", "macros", "test-util", "sync"]
+optional = true
+
+[dependencies.tokio-02]
+package = "tokio"
+version = "0.2"
+default-features = false
+features = ["time", "macros", "test-util", "rt-core", "sync"]
+optional = true
+
+[features]
+default = ["tokio-03"]


### PR DESCRIPTION
### Description of Changes

Changes default tokio version from 0.2 to 0.3. You can switch back to tokio 0.2 by using

```toml
tryhard = { version = "your-version", default-features = false, features = ["tokio-02"] }
```

### Related Issues

Fixes https://github.com/EmbarkStudios/tryhard/issues/1