### PR TITLE
Support Tokio 1.0 and drop support for Tokio 0.3

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fetch
-      - name: cargo test (tokio 0.3)
+      - name: cargo test (tokio 1.0)
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- N/A
+- Support for Tokio 1.0 added. Tokio 1.0 support is on by default or by enabling the `tokio-1` feature.
 
 ### Changed
 - N/A
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Removed
-- N/A
+- Support for Tokio 0.3 has been removed. 0.2 is still supported.
 
 ### Fixed
 - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["tokio", "futures", "retry"]
 futures = "0.3"
 pin-project = "1"
 
-[dependencies.tokio-03]
+[dependencies.tokio-1]
 package = "tokio"
-version = "0.3"
+version = "1"
 default-features = false
 features = ["rt", "time", "macros", "test-util", "sync"]
 optional = true
@@ -31,4 +31,4 @@ features = ["time", "macros", "test-util", "rt-core", "sync"]
 optional = true
 
 [features]
-default = ["tokio-03"]
+default = ["tokio-1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,14 +96,16 @@
 //! is because it makes use of async timers. Feel free to open an issue if you need support for
 //! other runtimes.
 //!
-//! By default it uses Tokio 0.3. You can switch to Tokio 0.2 by disabling default features and
+//! By default it uses Tokio 1.0. You can switch to Tokio 0.2 by disabling default features and
 //! enabling the `tokio-02` feature:
 //!
 //! ```toml
 //! tryhard = { version = "your-version", default-features = false, features = ["tokio-02"] }
 //! ```
 //!
-//! Note that enabling both Tokio 0.3 and 0.2 will cause a compilation error.
+//! Note that enabling both Tokio 1.0 and 0.2 will cause a compilation error.
+//!
+//! Tokio 0.3 is not supported.
 //!
 //! [`RetryFuture`]: struct.RetryFuture.html
 
@@ -125,11 +127,11 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(all(feature = "tokio-02", feature = "tokio-03"))]
-compile_error!("Cannot enable both tokio-02 and tokio-03 features");
+#[cfg(all(feature = "tokio-02", feature = "tokio-1"))]
+compile_error!("Cannot enable both tokio-02 and tokio-1 features");
 
-#[cfg(feature = "tokio-03")]
-use tokio_03 as tokio;
+#[cfg(feature = "tokio-1")]
+use tokio_1 as tokio;
 
 #[cfg(feature = "tokio-02")]
 use tokio_02 as tokio;
@@ -314,13 +316,13 @@ where
     ///
     /// ```
     /// use std::sync::Arc;
-    /// #[cfg(feature = "tokio-03")]
-    /// use tokio_03 as tokio;
+    /// #[cfg(feature = "tokio-1")]
+    /// use tokio_1 as tokio;
     /// #[cfg(feature = "tokio-02")]
     /// use tokio_02 as tokio;
     /// use tokio::sync::Mutex;
     ///
-    /// # #[cfg_attr(feature = "tokio-03", tokio::main(flavor = "current_thread"))]
+    /// # #[cfg_attr(feature = "tokio-1", tokio::main(flavor = "current_thread"))]
     /// # #[cfg_attr(feature = "tokio-02", tokio::main)]
     /// # async fn main() {
     /// let all_errors = Arc::new(Mutex::new(Vec::new()));
@@ -380,12 +382,13 @@ where
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[pin_project(project = RetryStateProj)]
 enum RetryState<F> {
     NotStarted,
     WaitingForFuture(#[pin] F),
 
-    #[cfg(feature = "tokio-03")]
+    #[cfg(feature = "tokio-1")]
     TimerActive(#[pin] tokio::time::Sleep),
 
     #[cfg(feature = "tokio-02")]
@@ -460,7 +463,7 @@ where
                                 ));
                             }
 
-                            #[cfg(feature = "tokio-03")]
+                            #[cfg(feature = "tokio-1")]
                             let delay = tokio::time::sleep(delay_duration);
 
                             #[cfg(feature = "tokio-02")]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Tokio 1.0 now supported and enabled by default (or through a `tokio-1` feature). Tokio 0.3 is no longer supported.
