### PR TITLE
Use `Into` in generic bounds instead of `From`

### DIFF
--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -86,12 +86,12 @@ pub struct CustomBackoffStrategy<F> {
 impl<F, E, T> BackoffStrategy<E> for CustomBackoffStrategy<F>
 where
     F: FnMut(u32, &E) -> T,
-    RetryPolicy: From<T>,
+    T: Into<RetryPolicy>,
 {
     type Output = RetryPolicy;
 
     #[inline]
     fn delay(&mut self, attempt: u32, error: &E) -> RetryPolicy {
-        RetryPolicy::from((self.f)(attempt, error))
+        (self.f)(attempt, error).into()
     }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

[From the standard library:](https://doc.rust-lang.org/stable/std/convert/trait.From.html)

> Prefer using Into over using From when specifying trait bounds on a generic function. This way, types that directly implement Into can be used as arguments as well.