### PR TITLE
More useful `Debug` impl for `CustomBackoffStrategy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Tokio 0.3 has been removed. 0.2 is still supported.
 
 ### Fixed
-- N/A
+- `CustomBackoffStrategy` now implements `Debug` regardless of its type parameter.
 
 ### Security
 - N/A


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`CustomBackoffStrategy` will often be used with closures which don't implement debug. So a debug impl that doesn't rely on `F: fmt::Debug` should be more useful.
