### PR TITLE
Add `RetryFutureConfig` which let you retry several futures in the same way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for Tokio 1.0 added. Tokio 1.0 support is on by default or by enabling the `tokio-1` feature.
 - Add `RetryFutureConfig` which let you retry several futures in the same way.
+- All backoff strategy types now implement `Copy` and `Clone`.
 
 ### Changed
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for Tokio 1.0 added. Tokio 1.0 support is on by default or by enabling the `tokio-1` feature.
+- Add `RetryFutureConfig` which let you retry several futures in the same way.
 
 ### Changed
 - N/A

--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -100,7 +100,7 @@ where
 impl<F> fmt::Debug for CustomBackoffStrategy<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CustomBackoffStrategy")
-            .field("f", &format_args!("{:?}", std::any::type_name::<F>()))
+            .field("f", &format_args!("<{}>", std::any::type_name::<F>()))
             .finish()
     }
 }
@@ -117,7 +117,7 @@ mod tests {
 
         assert_eq!(
             format!("{:?}", backoff),
-            "CustomBackoffStrategy { f: \"tryhard::backoff_strategies::tests::custom_has_useful_debug_impl::{{closure}}\" }",
+            "CustomBackoffStrategy { f: <tryhard::backoff_strategies::tests::custom_has_useful_debug_impl::{{closure}}> }",
         );
     }
 }

--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -19,7 +19,7 @@ pub trait BackoffStrategy<E> {
 
 /// No backoff. This will make the future be retried immediately without any delay in between
 /// attempts.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct NoBackoff;
 
 impl<E> BackoffStrategy<E> for NoBackoff {
@@ -32,7 +32,7 @@ impl<E> BackoffStrategy<E> for NoBackoff {
 }
 
 /// Exponential backoff. The delay will double each time.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ExponentialBackoff {
     pub(crate) delay: Duration,
 }
@@ -49,7 +49,7 @@ impl<E> BackoffStrategy<E> for ExponentialBackoff {
 }
 
 /// Fixed backoff. The delay wont change between attempts.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct FixedBackoff {
     pub(crate) delay: Duration,
 }
@@ -64,7 +64,7 @@ impl<E> BackoffStrategy<E> for FixedBackoff {
 }
 
 /// Linear backoff. The delay will scale linearly with the number of attempts.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct LinearBackoff {
     pub(crate) delay: Duration,
 }
@@ -79,6 +79,7 @@ impl<E> BackoffStrategy<E> for LinearBackoff {
 }
 
 /// A custom backoff strategy defined by a function.
+#[derive(Clone, Copy)]
 pub struct CustomBackoffStrategy<F> {
     pub(crate) f: F,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,59 @@
 //! # }
 //! ```
 //!
+//! You can also customize which backoff strategy to use and what the max retry delay should be:
+//!
+//! ```
+//! use std::time::Duration;
+//!
+//! # async fn read_file(path: &str) -> Result<String, std::io::Error> {
+//! #     Ok("tryhard".to_string())
+//! # }
+//! # futures::executor::block_on(async_try_main()).unwrap();
+//! #
+//! # async fn async_try_main() -> Result<(), Box<dyn std::error::Error>> {
+//! let contents = tryhard::retry_fn(|| read_file("Cargo.toml"))
+//!     .retries(10)
+//!     .exponential_backoff(Duration::from_millis(10))
+//!     .max_delay(Duration::from_secs(1))
+//!     .await?;
+//!
+//! assert!(contents.contains("tryhard"));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Retrying several futures in the same way
+//!
+//! Using [`RetryFutureConfig`] you're able to retry several futures in the same way:
+//!
+//! ```
+//! # use std::time::Duration;
+//! # async fn read_file(path: &str) -> Result<String, std::io::Error> {
+//! #     Ok("tryhard".to_string())
+//! # }
+//! #
+//! # futures::executor::block_on(async_try_main()).unwrap();
+//! #
+//! # async fn async_try_main() -> Result<(), Box<dyn std::error::Error>> {
+//! use tryhard::RetryFutureConfig;
+//!
+//! let config = RetryFutureConfig::retries(10)
+//!     .exponential_backoff(Duration::from_millis(10))
+//!     .max_delay(Duration::from_secs(3));
+//!
+//! tryhard::retry_fn(|| read_file("Cargo.toml"))
+//!     .with_config(config)
+//!     .await?;
+//!
+//! // retry another future in the same way
+//! tryhard::retry_fn(|| read_file("src/lib.rs"))
+//!     .with_config(config)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## How many times will my future run?
 //!
 //! The future is always run at least once, so if you do `.retries(0)` your future will run once.
@@ -159,14 +212,24 @@ impl<F> RetryFn<F> {
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, E>>,
     {
+        self.with_config(RetryFutureConfig::retries(max_retries))
+    }
+
+    /// Create a retryable future from the given configuration.
+    pub fn with_config<Fut, T, E, BackoffT, OnRetryT>(
+        self,
+        config: RetryFutureConfig<BackoffT, OnRetryT>,
+    ) -> RetryFuture<F, Fut, BackoffT, OnRetryT>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
         RetryFuture {
             make_future: self.f,
-            attempts_remaining: max_retries,
-            backoff_strategy: NoBackoff,
-            max_delay: None,
+            attempts_remaining: config.max_retries,
             state: RetryState::NotStarted,
             attempt: 0,
-            on_retry: None::<Infallible>,
+            config,
         }
     }
 }
@@ -178,12 +241,10 @@ impl<F> RetryFn<F> {
 pub struct RetryFuture<MakeFutureT, FutureT, BackoffT, OnRetryT> {
     make_future: MakeFutureT,
     attempts_remaining: u32,
-    backoff_strategy: BackoffT,
-    max_delay: Option<Duration>,
     #[pin]
     state: RetryState<FutureT>,
     attempt: u32,
-    on_retry: Option<OnRetryT>,
+    config: RetryFutureConfig<BackoffT, OnRetryT>,
 }
 
 impl<MakeFutureT, FutureT, BackoffT, T, E, OnRetryT>
@@ -195,7 +256,7 @@ where
     /// Set the max duration to sleep between each attempt.
     #[inline]
     pub fn max_delay(mut self, delay: Duration) -> Self {
-        self.max_delay = Some(delay);
+        self.config = self.config.max_delay(delay);
         self
     }
 
@@ -357,11 +418,9 @@ where
         RetryFuture {
             make_future: self.make_future,
             attempts_remaining: self.attempts_remaining,
-            backoff_strategy: self.backoff_strategy,
-            max_delay: self.max_delay,
             state: self.state,
             attempt: self.attempt,
-            on_retry: Some(f),
+            config: self.config.on_retry(f),
         }
     }
 
@@ -373,10 +432,123 @@ where
         RetryFuture {
             make_future: self.make_future,
             attempts_remaining: self.attempts_remaining,
-            backoff_strategy,
-            max_delay: self.max_delay,
             state: self.state,
             attempt: self.attempt,
+            config: self.config.with_backoff(backoff_strategy),
+        }
+    }
+}
+
+/// Configuration describing how to retry a future.
+///
+/// This is useful if you have many futures you want to retry in the same way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryFutureConfig<BackoffT, OnRetryT> {
+    backoff_strategy: BackoffT,
+    max_delay: Option<Duration>,
+    on_retry: Option<OnRetryT>,
+    max_retries: u32,
+}
+
+impl RetryFutureConfig<NoBackoff, Infallible> {
+    /// Create a new configuration with a max number of retries and no backoff strategy.
+    pub fn retries(max_retries: u32) -> Self {
+        Self {
+            backoff_strategy: NoBackoff,
+            max_delay: None,
+            on_retry: None::<Infallible>,
+            max_retries,
+        }
+    }
+}
+
+impl<BackoffT, OnRetryT> RetryFutureConfig<BackoffT, OnRetryT> {
+    /// Set the max duration to sleep between each attempt.
+    #[inline]
+    pub fn max_delay(mut self, delay: Duration) -> Self {
+        self.max_delay = Some(delay);
+        self
+    }
+
+    /// Remove the backoff strategy.
+    ///
+    /// This will make the future be retried immediately without any delay in between attempts.
+    #[inline]
+    pub fn no_backoff(self) -> RetryFutureConfig<NoBackoff, OnRetryT> {
+        self.with_backoff(NoBackoff)
+    }
+
+    /// Use exponential backoff for retrying the future.
+    ///
+    /// The first delay will be `initial_delay` and afterwards the delay will double every time.
+    #[inline]
+    pub fn exponential_backoff(
+        self,
+        initial_delay: Duration,
+    ) -> RetryFutureConfig<ExponentialBackoff, OnRetryT> {
+        self.with_backoff(ExponentialBackoff {
+            delay: initial_delay,
+        })
+    }
+
+    /// Use a fixed backoff for retrying the future.
+    ///
+    /// The delay between attempts will always be `delay`.
+    #[inline]
+    pub fn fixed_backoff(self, delay: Duration) -> RetryFutureConfig<FixedBackoff, OnRetryT> {
+        self.with_backoff(FixedBackoff { delay })
+    }
+
+    /// Use a linear backoff for retrying the future.
+    ///
+    /// The delay will be `delay * attempt` so it'll scale linear with the attempt.
+    #[inline]
+    pub fn linear_backoff(self, delay: Duration) -> RetryFutureConfig<LinearBackoff, OnRetryT> {
+        self.with_backoff(LinearBackoff { delay })
+    }
+
+    /// Use a custom backoff specified by some function.
+    ///
+    /// See [`RetryFuture::custom_backoff`] for more details.
+    #[inline]
+    pub fn custom_backoff<F, R, E>(
+        self,
+        f: F,
+    ) -> RetryFutureConfig<CustomBackoffStrategy<F>, OnRetryT>
+    where
+        F: FnMut(u32, &E) -> R,
+        R: Into<RetryPolicy>,
+    {
+        self.with_backoff(CustomBackoffStrategy { f })
+    }
+
+    /// Some async computation that will be spawned before each retry.
+    ///
+    /// See [`RetryFuture::on_retry`] for more details.
+    #[inline]
+    pub fn on_retry<F, OnRetryFuture, E>(self, f: F) -> RetryFutureConfig<BackoffT, F>
+    where
+        F: FnMut(u32, Option<Duration>, &E) -> OnRetryFuture,
+        OnRetryFuture: Future + Send + 'static,
+        OnRetryFuture::Output: Send + 'static,
+    {
+        RetryFutureConfig {
+            backoff_strategy: self.backoff_strategy,
+            max_delay: self.max_delay,
+            max_retries: self.max_retries,
+            on_retry: Some(f),
+        }
+    }
+
+    #[inline]
+    fn with_backoff<BackoffT2>(
+        self,
+        backoff_strategy: BackoffT2,
+    ) -> RetryFutureConfig<BackoffT2, OnRetryT> {
+        RetryFutureConfig {
+            backoff_strategy,
+            max_delay: self.max_delay,
+            max_retries: self.max_retries,
             on_retry: self.on_retry,
         }
     }
@@ -424,7 +596,7 @@ where
                     }
                     Err(error) => {
                         if *this.attempts_remaining == 0 {
-                            if let Some(on_retry) = this.on_retry {
+                            if let Some(on_retry) = &mut this.config.on_retry {
                                 tokio::spawn(on_retry.on_retry(*this.attempt, None, &error));
                             }
 
@@ -434,11 +606,11 @@ where
                             *this.attempts_remaining -= 1;
 
                             let delay: RetryPolicy =
-                                this.backoff_strategy.delay(*this.attempt, &error).into();
+                                this.config.backoff_strategy.delay(*this.attempt, &error).into();
                             let mut delay_duration = match delay {
                                 RetryPolicy::Delay(duration) => duration,
                                 RetryPolicy::Break => {
-                                    if let Some(on_retry) = this.on_retry {
+                                    if let Some(on_retry) = &mut this.config.on_retry {
                                         tokio::spawn(on_retry.on_retry(
                                             *this.attempt,
                                             None,
@@ -450,11 +622,11 @@ where
                                 }
                             };
 
-                            if let Some(max_delay) = this.max_delay {
-                                delay_duration = delay_duration.min(*max_delay);
+                            if let Some(max_delay) = this.config.max_delay {
+                                delay_duration = delay_duration.min(max_delay);
                             }
 
-                            if let Some(on_retry) = this.on_retry {
+                            if let Some(on_retry) = &mut this.config.on_retry {
                                 tokio::spawn(on_retry.on_retry(
                                     *this.attempt,
                                     Some(delay_duration),
@@ -555,6 +727,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::{convert::Infallible, time::Instant};
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn succeed() {
@@ -695,5 +868,34 @@ mod tests {
                 &(n, Some(Duration::new(0, 0)), "error".to_string())
             );
         }
+    }
+
+    #[tokio::test]
+    async fn reusing_the_config() {
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let config = RetryFutureConfig::retries(10)
+            .max_delay(Duration::from_secs(1))
+            .linear_backoff(Duration::from_millis(10))
+            .on_retry(|_, _, _| {
+                let counter = Arc::clone(&counter);
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+
+        let ok_value = retry_fn(|| async { Ok::<_, &str>(true) })
+            .with_config(config)
+            .await
+            .unwrap();
+        assert!(ok_value);
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+        let err_value = retry_fn(|| async { Err::<(), _>("foo") })
+            .with_config(config)
+            .await
+            .unwrap_err();
+        assert_eq!(err_value, "foo");
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@ pub trait OnRetry<E> {
     ) -> Self::Future;
 }
 
-/// A sentinel value that represents doing nothing in between retries futures.
+/// A sentinel value that represents doing nothing in between retries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoOnRetry {
     _cannot_exist: Infallible,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,25 +202,21 @@ pub struct RetryFn<F> {
     f: F,
 }
 
-impl<F> RetryFn<F> {
+impl<F, Fut, T, E> RetryFn<F>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
     /// Specify the number of times to retry the future.
-    pub fn retries<Fut, T, E>(self, max_retries: u32) -> RetryFuture<F, Fut, NoBackoff, NoOnRetry>
-    where
-        F: FnMut() -> Fut,
-        Fut: Future<Output = Result<T, E>>,
-    {
+    pub fn retries(self, max_retries: u32) -> RetryFuture<F, Fut, NoBackoff, NoOnRetry> {
         self.with_config(RetryFutureConfig::retries(max_retries))
     }
 
     /// Create a retryable future from the given configuration.
-    pub fn with_config<Fut, T, E, BackoffT, OnRetryT>(
+    pub fn with_config<BackoffT, OnRetryT>(
         self,
         config: RetryFutureConfig<BackoffT, OnRetryT>,
-    ) -> RetryFuture<F, Fut, BackoffT, OnRetryT>
-    where
-        F: FnMut() -> Fut,
-        Fut: Future<Output = Result<T, E>>,
-    {
+    ) -> RetryFuture<F, Fut, BackoffT, OnRetryT> {
         RetryFuture {
             make_future: self.f,
             attempts_remaining: config.max_retries,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,8 +605,11 @@ where
                             *this.attempt += 1;
                             *this.attempts_remaining -= 1;
 
-                            let delay: RetryPolicy =
-                                this.config.backoff_strategy.delay(*this.attempt, &error).into();
+                            let delay: RetryPolicy = this
+                                .config
+                                .backoff_strategy
+                                .delay(*this.attempt, &error)
+                                .into();
                             let mut delay_duration = match delay {
                                 RetryPolicy::Delay(duration) => duration,
                                 RetryPolicy::Break => {
@@ -733,8 +736,8 @@ where
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::{convert::Infallible, time::Instant};
     use std::sync::Arc;
+    use std::{convert::Infallible, time::Instant};
 
     #[tokio::test]
     async fn succeed() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,10 +204,7 @@ pub struct RetryFn<F> {
 
 impl<F> RetryFn<F> {
     /// Specify the number of times to retry the future.
-    pub fn retries<Fut, T, E>(
-        self,
-        max_retries: u32,
-    ) -> RetryFuture<F, Fut, NoBackoff, impl OnRetry<E>>
+    pub fn retries<Fut, T, E>(self, max_retries: u32) -> RetryFuture<F, Fut, NoBackoff, NoOnRetry>
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, E>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,7 +558,7 @@ where
             .field("max_retries", &self.max_retries)
             .field(
                 "on_retry",
-                &format_args!("{:?}", std::any::type_name::<OnRetryT>()),
+                &format_args!("<{}>", std::any::type_name::<OnRetryT>()),
             )
             .finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! # async fn async_try_main() -> Result<(), Box<dyn std::error::Error>> {
 //! use tryhard::RetryFutureConfig;
 //!
-//! let config = RetryFutureConfig::retries(10)
+//! let config = RetryFutureConfig::new(10)
 //!     .exponential_backoff(Duration::from_millis(10))
 //!     .max_delay(Duration::from_secs(3));
 //!
@@ -209,7 +209,7 @@ where
 {
     /// Specify the number of times to retry the future.
     pub fn retries(self, max_retries: u32) -> RetryFuture<F, Fut, NoBackoff, NoOnRetry> {
-        self.with_config(RetryFutureConfig::retries(max_retries))
+        self.with_config(RetryFutureConfig::new(max_retries))
     }
 
     /// Create a retryable future from the given configuration.
@@ -445,7 +445,7 @@ pub struct RetryFutureConfig<BackoffT, OnRetryT> {
 
 impl RetryFutureConfig<NoBackoff, NoOnRetry> {
     /// Create a new configuration with a max number of retries and no backoff strategy.
-    pub fn retries(max_retries: u32) -> Self {
+    pub fn new(max_retries: u32) -> Self {
         Self {
             backoff_strategy: NoBackoff,
             max_delay: None,
@@ -894,7 +894,7 @@ mod tests {
     async fn reusing_the_config() {
         let counter = Arc::new(AtomicUsize::new(0));
 
-        let config = RetryFutureConfig::retries(10)
+        let config = RetryFutureConfig::new(10)
             .max_delay(Duration::from_secs(1))
             .linear_backoff(Duration::from_millis(10))
             .on_retry(|_, _, _| {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

In one of Embark's projects we're retrying a bunch of futures in the same way. That leads to a bit of duplication. This should rectify that.

Example usage:

```rust
let config = RetryFutureConfig::retries(10)
    .max_delay(Duration::from_secs(1))
    .linear_backoff(Duration::from_millis(10));

retry_fn(|| async { Ok::<_, &str>(true) })
    .with_config(config)
    .await
    .unwrap();

retry_fn(|| async { Err::<(), _>("foo") })
    .with_config(config)
    .await
    .unwrap();
```