### PR TITLE
Make it easier to name `RetryFutureConfig` types

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -54,16 +54,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fetch
-      - name: cargo test (tokio 1.0)
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release
-      - name: cargo test (tokio 0.2)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features --features tokio-02
 
   publish-check:
     name: Publish Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit constructs have been added to each back-off strategy. This makes it
   possible to define a new strategy that wraps one of the types provided by
   tryhard.
-- `NoOnRetry` now has a public constructor.
 
 ### Changed
 - `BackoffStrategy` is now generic over the lifetime of the error given to
   `BackoffStrategy::delay`.
 - The output of the future returned by `OnRetry::on_retry` has been
   fixed to `()`. As the future is given to `tokio::spawn` requiring `()` is
-  nicer. It also simplified some trait bounds on `BoxOnRetry`.
-- `RetryFuture` no longer requires the error type to implement `Display`.
+  nicer.
 
 ### Deprecated
 - N/A
@@ -31,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supported.
 
 ### Fixed
-- N/A
+- `RetryFuture` no longer requires the error type to implement `Display`.
 
 ### Security
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 ### Added
-- N/A
+- Added `RetryFutureConfig::boxed_on_retry` which converts the `on_retry`
+  callback into a boxed trait object which makes the type easier to name.
 
 ### Changed
-- N/A
+- `OnRetry::on_retry` no longer receives `&mut self` but instead
+  `&self`. That was necessary to implement `BoxOnRetry`. Users who need mutation
+  in their callbacks should use a mutex.
+- The output of the future returned by `OnRetry::on_retry` has been
+  fixed to `()`. As the future is given to `tokio::spawn` I think requiring `()`
+  is nicer. It also simplified some trait bounds on `BoxOnRetry`.
 
 ### Deprecated
 - N/A
 
 ### Removed
-- N/A
+- Tokio 0.2 support has been removed. Tokio 1 is now the only version
+  supported.
 
 ### Fixed
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `RetryFutureConfig::boxed_on_retry` which converts the `on_retry`
-  callback into a boxed trait object which makes the type easier to name.
+- `BackoffStrategy` is now implemented directly for functions of the right type.
+- Explicit constructs have been added to each back-off strategy. This makes it
+  possible to define a new strategy that wraps one of the types provided by
+  tryhard.
+- Added `RetryFutureConfig::const_new` which can be used to construct a
+  `RetryFutureConfig` in a `const` context.
+- `NoOnRetry` now has a public constructor.
 
 ### Changed
-- `OnRetry::on_retry` no longer receives `&mut self` but instead
-  `&self`. That was necessary to implement `BoxOnRetry`. Users who need mutation
-  in their callbacks should use a mutex.
+- `BackoffStrategy` is now generic over the lifetime of the error given to
+  `BackoffStrategy::delay`.
 - The output of the future returned by `OnRetry::on_retry` has been
-  fixed to `()`. As the future is given to `tokio::spawn` I think requiring `()`
-  is nicer. It also simplified some trait bounds on `BoxOnRetry`.
+  fixed to `()`. As the future is given to `tokio::spawn` requiring `()` is
+  nicer. It also simplified some trait bounds on `BoxOnRetry`.
 
 ### Deprecated
 - N/A
 
 ### Removed
+- `CustomBackoffStrategy` has been removed since `BackoffStrategy` is now
+  implemented directly on functions of the right type.
 - Tokio 0.2 support has been removed. Tokio 1 is now the only version
   supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit constructs have been added to each back-off strategy. This makes it
   possible to define a new strategy that wraps one of the types provided by
   tryhard.
-- Added `RetryFutureConfig::const_new` which can be used to construct a
-  `RetryFutureConfig` in a `const` context.
 - `NoOnRetry` now has a public constructor.
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,8 @@ keywords = ["tokio", "futures", "retry"]
 futures = "0.3"
 pin-project = "1"
 
-[dependencies.tokio-1]
+[dependencies.tokio]
 package = "tokio"
 version = "1"
 default-features = false
 features = ["rt", "time", "macros", "test-util", "sync"]
-optional = true
-
-[dependencies.tokio-02]
-package = "tokio"
-version = "0.2"
-default-features = false
-features = ["time", "macros", "test-util", "rt-core", "sync"]
-optional = true
-
-[features]
-default = ["tokio-1"]

--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -38,7 +38,7 @@ pub struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     /// Create a new `ExponentialBackoff` with an initial delay.
-    pub const fn new(initial_delay: Duration) -> Self {
+    pub fn new(initial_delay: Duration) -> Self {
         Self {
             delay: initial_delay,
         }
@@ -64,7 +64,7 @@ pub struct FixedBackoff {
 
 impl FixedBackoff {
     /// Create a new `FixedBackoff` with an initial delay.
-    pub const fn new(initial_delay: Duration) -> Self {
+    pub fn new(initial_delay: Duration) -> Self {
         Self {
             delay: initial_delay,
         }
@@ -88,7 +88,7 @@ pub struct LinearBackoff {
 
 impl LinearBackoff {
     /// Create a new `LinearBackoff` with an initial delay.
-    pub const fn new(initial_delay: Duration) -> Self {
+    pub fn new(initial_delay: Duration) -> Self {
         Self {
             delay: initial_delay,
         }

--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -1,11 +1,10 @@
 //! The types of backoff strategies that are supported
 
 use crate::RetryPolicy;
-use std::fmt;
 use std::time::Duration;
 
 /// Trait for computing the amount of delay between attempts.
-pub trait BackoffStrategy<E> {
+pub trait BackoffStrategy<'a, E> {
     /// The delay type. Will normally be either [`Duration`] or [`RetryPolicy`].
     ///
     /// [`Duration`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html
@@ -14,7 +13,7 @@ pub trait BackoffStrategy<E> {
 
     /// Compute the amount of delay given the number of attempts so far and the most previous
     /// error.
-    fn delay(&mut self, attempt: u32, error: &E) -> Self::Output;
+    fn delay(&mut self, attempt: u32, error: &'a E) -> Self::Output;
 }
 
 /// No backoff. This will make the future be retried immediately without any delay in between
@@ -22,11 +21,11 @@ pub trait BackoffStrategy<E> {
 #[derive(Debug, Clone, Copy)]
 pub struct NoBackoff;
 
-impl<E> BackoffStrategy<E> for NoBackoff {
+impl<'a, E> BackoffStrategy<'a, E> for NoBackoff {
     type Output = Duration;
 
     #[inline]
-    fn delay(&mut self, _attempt: u32, _error: &E) -> Duration {
+    fn delay(&mut self, _attempt: u32, _error: &'a E) -> Duration {
         Duration::new(0, 0)
     }
 }
@@ -37,11 +36,20 @@ pub struct ExponentialBackoff {
     pub(crate) delay: Duration,
 }
 
-impl<E> BackoffStrategy<E> for ExponentialBackoff {
+impl ExponentialBackoff {
+    /// Create a new `ExponentialBackoff` with an initial delay.
+    pub const fn new(initial_delay: Duration) -> Self {
+        Self {
+            delay: initial_delay,
+        }
+    }
+}
+
+impl<'a, E> BackoffStrategy<'a, E> for ExponentialBackoff {
     type Output = Duration;
 
     #[inline]
-    fn delay(&mut self, _attempt: u32, _error: &E) -> Duration {
+    fn delay(&mut self, _attempt: u32, _error: &'a E) -> Duration {
         let prev_delay = self.delay;
         self.delay *= 2;
         prev_delay
@@ -54,11 +62,20 @@ pub struct FixedBackoff {
     pub(crate) delay: Duration,
 }
 
-impl<E> BackoffStrategy<E> for FixedBackoff {
+impl FixedBackoff {
+    /// Create a new `FixedBackoff` with an initial delay.
+    pub const fn new(initial_delay: Duration) -> Self {
+        Self {
+            delay: initial_delay,
+        }
+    }
+}
+
+impl<'a, E> BackoffStrategy<'a, E> for FixedBackoff {
     type Output = Duration;
 
     #[inline]
-    fn delay(&mut self, _attempt: u32, _error: &E) -> Duration {
+    fn delay(&mut self, _attempt: u32, _error: &'a E) -> Duration {
         self.delay
     }
 }
@@ -69,55 +86,34 @@ pub struct LinearBackoff {
     pub(crate) delay: Duration,
 }
 
-impl<E> BackoffStrategy<E> for LinearBackoff {
+impl LinearBackoff {
+    /// Create a new `LinearBackoff` with an initial delay.
+    pub const fn new(initial_delay: Duration) -> Self {
+        Self {
+            delay: initial_delay,
+        }
+    }
+}
+
+impl<'a, E> BackoffStrategy<'a, E> for LinearBackoff {
     type Output = Duration;
 
     #[inline]
-    fn delay(&mut self, attempt: u32, _error: &E) -> Duration {
+    fn delay(&mut self, attempt: u32, _error: &'a E) -> Duration {
         self.delay * attempt
     }
 }
 
-/// A custom backoff strategy defined by a function.
-#[derive(Clone, Copy)]
-pub struct CustomBackoffStrategy<F> {
-    pub(crate) f: F,
-}
-
-impl<F, E, T> BackoffStrategy<E> for CustomBackoffStrategy<F>
+impl<'a, F, E, T> BackoffStrategy<'a, E> for F
 where
-    F: FnMut(u32, &E) -> T,
+    E: 'a,
+    F: FnMut(u32, &'a E) -> T,
     T: Into<RetryPolicy>,
 {
     type Output = RetryPolicy;
 
     #[inline]
-    fn delay(&mut self, attempt: u32, error: &E) -> RetryPolicy {
-        (self.f)(attempt, error).into()
-    }
-}
-
-impl<F> fmt::Debug for CustomBackoffStrategy<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CustomBackoffStrategy")
-            .field("f", &format_args!("<{}>", std::any::type_name::<F>()))
-            .finish()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::convert::Infallible;
-
-    #[test]
-    fn custom_has_useful_debug_impl() {
-        let f = |_: u32, _: Infallible| Duration::from_secs(1);
-        let backoff = CustomBackoffStrategy { f };
-
-        assert_eq!(
-            format!("{:?}", backoff),
-            "CustomBackoffStrategy { f: <tryhard::backoff_strategies::tests::custom_has_useful_debug_impl::{{closure}}> }",
-        );
+    fn delay(&mut self, attempt: u32, error: &'a E) -> RetryPolicy {
+        self(attempt, error).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,7 @@ impl<BackoffT, OnRetryT> RetryFutureConfig<BackoffT, OnRetryT> {
     /// [`on_retry`]: RetryFutureConfig::on_retry
     pub fn boxed_on_retry<E>(self) -> RetryFutureConfig<BackoffT, BoxOnRetry<E>>
     where
-        OnRetryT: OnRetry<E> + 'static,
+        OnRetryT: OnRetry<E> + Send + Sync + 'static,
         OnRetryT::Future: Send + Sync + 'static,
     {
         RetryFutureConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,37 +449,6 @@ impl RetryFutureConfig<NoBackoff, NoOnRetry> {
 }
 
 impl<BackoffT, OnRetryT> RetryFutureConfig<BackoffT, OnRetryT> {
-    /// Create a new `RetryFutureConfig`.
-    ///
-    /// This method is usable in "const context":
-    ///
-    /// ```rust
-    /// use std::time::Duration;
-    /// use tryhard::{RetryFutureConfig, NoOnRetry, backoff_strategies::LinearBackoff};
-    ///
-    /// const CONFIG: RetryFutureConfig<LinearBackoff, NoOnRetry> = RetryFutureConfig::const_new(
-    ///     10,
-    ///     LinearBackoff::new(Duration::from_millis(10)),
-    ///     Some(Duration::from_secs(10)),
-    ///     NoOnRetry,
-    /// );
-    /// ```
-    pub const fn const_new(
-        max_retries: u32,
-        backoff_strategy: BackoffT,
-        max_delay: Option<Duration>,
-        on_retry: OnRetryT,
-    ) -> Self {
-        Self {
-            backoff_strategy,
-            max_delay,
-            on_retry,
-            max_retries,
-        }
-    }
-}
-
-impl<BackoffT, OnRetryT> RetryFutureConfig<BackoffT, OnRetryT> {
     /// Set the max duration to sleep between each attempt.
     #[inline]
     pub fn max_delay(mut self, delay: Duration) -> Self {

--- a/src/on_retry.rs
+++ b/src/on_retry.rs
@@ -1,5 +1,5 @@
 use futures::future::Ready;
-use std::{future::Future, time::Duration};
+use std::{convert::Infallible, future::Future, time::Duration};
 
 /// Trait allowing you to run some future when a retry occurs. Could for example to be used for
 /// logging or other kinds of telemetry.
@@ -23,14 +23,16 @@ pub trait OnRetry<E> {
 
 /// A sentinel value that represents doing nothing in between retries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NoOnRetry;
+pub struct NoOnRetry {
+    cannot_exist: Infallible,
+}
 
 impl<E> OnRetry<E> for NoOnRetry {
     type Future = Ready<()>;
 
     #[inline]
     fn on_retry(&mut self, _: u32, _: Option<Duration>, _: &E) -> Self::Future {
-        futures::future::ready(())
+        match self.cannot_exist {}
     }
 }
 

--- a/src/on_retry.rs
+++ b/src/on_retry.rs
@@ -1,0 +1,123 @@
+use futures::future::{BoxFuture, Ready};
+use std::{convert::Infallible, fmt, future::Future, sync::Arc, time::Duration};
+
+/// Trait allowing you to run some future when a retry occurs. Could for example to be used for
+/// logging or other kinds of telemetry.
+///
+/// You wont have to implement this trait manually. It is implemented for functions with the right
+/// signature. See [`RetryFuture::on_retry`](struct.RetryFuture.html#method.on_retry) for more details.
+pub trait OnRetry<E> {
+    /// The type of the future you want to run.
+    type Future: 'static + Future<Output = ()> + Send;
+
+    /// Create another future to run.
+    ///
+    /// If `next_delay` is `None` then your future is out of retries and wont be called again.
+    fn on_retry(
+        &self,
+        attempt: u32,
+        next_delay: Option<Duration>,
+        previous_error: &E,
+    ) -> Self::Future;
+}
+
+/// A sentinel value that represents doing nothing in between retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoOnRetry {
+    cannot_exist: Infallible,
+}
+
+impl<E> OnRetry<E> for NoOnRetry {
+    type Future = Ready<()>;
+
+    #[inline]
+    fn on_retry(&self, _: u32, _: Option<Duration>, _: &E) -> Self::Future {
+        match self.cannot_exist {}
+    }
+}
+
+impl<F, E, FutureT> OnRetry<E> for F
+where
+    F: Fn(u32, Option<Duration>, &E) -> FutureT,
+    FutureT: Future<Output = ()> + Send + 'static,
+    FutureT::Output: Send + 'static,
+{
+    type Future = FutureT;
+
+    #[inline]
+    fn on_retry(
+        &self,
+        attempts: u32,
+        next_delay: Option<Duration>,
+        previous_error: &E,
+    ) -> Self::Future {
+        self(attempts, next_delay, previous_error)
+    }
+}
+
+/// A boxed [`OnRetry`] trait object.
+///
+/// Created via [`RetryFutureConfig::boxed_on_retry`].
+///
+/// [`RetryFutureConfig::boxed_on_retry`]: crate::RetryFutureConfig::boxed_on_retry
+pub struct BoxOnRetry<E> {
+    inner: Arc<dyn OnRetry<E, Future = BoxFuture<'static, ()>>>,
+}
+
+impl<E> Clone for BoxOnRetry<E> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<E> fmt::Debug for BoxOnRetry<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxOnRetry").finish()
+    }
+}
+
+// On `OnRetry` adapter that boxes the future
+struct BoxOnRetryFuture<T>(T);
+
+impl<T, E> OnRetry<E> for BoxOnRetryFuture<T>
+where
+    T: OnRetry<E>,
+{
+    type Future = BoxFuture<'static, ()>;
+
+    fn on_retry(
+        &self,
+        attempt: u32,
+        next_delay: Option<Duration>,
+        previous_error: &E,
+    ) -> Self::Future {
+        Box::pin(self.0.on_retry(attempt, next_delay, previous_error))
+    }
+}
+
+impl<E> BoxOnRetry<E> {
+    pub(crate) fn new<T>(inner: T) -> Self
+    where
+        T: OnRetry<E> + 'static,
+        T::Future: Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(BoxOnRetryFuture(inner)),
+        }
+    }
+}
+
+impl<E> OnRetry<E> for BoxOnRetry<E> {
+    type Future = BoxFuture<'static, ()>;
+
+    fn on_retry(
+        &self,
+        attempt: u32,
+        next_delay: Option<Duration>,
+        previous_error: &E,
+    ) -> Self::Future {
+        self.inner.on_retry(attempt, next_delay, previous_error)
+    }
+}

--- a/src/on_retry.rs
+++ b/src/on_retry.rs
@@ -61,7 +61,7 @@ where
 ///
 /// [`RetryFutureConfig::boxed_on_retry`]: crate::RetryFutureConfig::boxed_on_retry
 pub struct BoxOnRetry<E> {
-    inner: Arc<dyn OnRetry<E, Future = BoxFuture<'static, ()>>>,
+    inner: Arc<dyn OnRetry<E, Future = BoxFuture<'static, ()>> + Send + Sync + 'static>,
 }
 
 impl<E> Clone for BoxOnRetry<E> {
@@ -100,7 +100,7 @@ where
 impl<E> BoxOnRetry<E> {
     pub(crate) fn new<T>(inner: T) -> Self
     where
-        T: OnRetry<E> + 'static,
+        T: OnRetry<E> + Send + Sync + 'static,
         T::Future: Send + Sync + 'static,
     {
         Self {

--- a/src/on_retry.rs
+++ b/src/on_retry.rs
@@ -1,5 +1,5 @@
-use futures::future::{BoxFuture, Ready};
-use std::{convert::Infallible, fmt, future::Future, sync::Arc, time::Duration};
+use futures::future::Ready;
+use std::{future::Future, time::Duration};
 
 /// Trait allowing you to run some future when a retry occurs. Could for example to be used for
 /// logging or other kinds of telemetry.
@@ -8,13 +8,13 @@ use std::{convert::Infallible, fmt, future::Future, sync::Arc, time::Duration};
 /// signature. See [`RetryFuture::on_retry`](struct.RetryFuture.html#method.on_retry) for more details.
 pub trait OnRetry<E> {
     /// The type of the future you want to run.
-    type Future: 'static + Future<Output = ()> + Send;
+    type Future: Future<Output = ()> + Send + 'static;
 
     /// Create another future to run.
     ///
     /// If `next_delay` is `None` then your future is out of retries and wont be called again.
     fn on_retry(
-        &self,
+        &mut self,
         attempt: u32,
         next_delay: Option<Duration>,
         previous_error: &E,
@@ -23,16 +23,14 @@ pub trait OnRetry<E> {
 
 /// A sentinel value that represents doing nothing in between retries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NoOnRetry {
-    cannot_exist: Infallible,
-}
+pub struct NoOnRetry;
 
 impl<E> OnRetry<E> for NoOnRetry {
     type Future = Ready<()>;
 
     #[inline]
-    fn on_retry(&self, _: u32, _: Option<Duration>, _: &E) -> Self::Future {
-        match self.cannot_exist {}
+    fn on_retry(&mut self, _: u32, _: Option<Duration>, _: &E) -> Self::Future {
+        futures::future::ready(())
     }
 }
 
@@ -46,78 +44,11 @@ where
 
     #[inline]
     fn on_retry(
-        &self,
+        &mut self,
         attempts: u32,
         next_delay: Option<Duration>,
         previous_error: &E,
     ) -> Self::Future {
         self(attempts, next_delay, previous_error)
-    }
-}
-
-/// A boxed [`OnRetry`] trait object.
-///
-/// Created via [`RetryFutureConfig::boxed_on_retry`].
-///
-/// [`RetryFutureConfig::boxed_on_retry`]: crate::RetryFutureConfig::boxed_on_retry
-pub struct BoxOnRetry<E> {
-    inner: Arc<dyn OnRetry<E, Future = BoxFuture<'static, ()>> + Send + Sync + 'static>,
-}
-
-impl<E> Clone for BoxOnRetry<E> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-impl<E> fmt::Debug for BoxOnRetry<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BoxOnRetry").finish()
-    }
-}
-
-// On `OnRetry` adapter that boxes the future
-struct BoxOnRetryFuture<T>(T);
-
-impl<T, E> OnRetry<E> for BoxOnRetryFuture<T>
-where
-    T: OnRetry<E>,
-{
-    type Future = BoxFuture<'static, ()>;
-
-    fn on_retry(
-        &self,
-        attempt: u32,
-        next_delay: Option<Duration>,
-        previous_error: &E,
-    ) -> Self::Future {
-        Box::pin(self.0.on_retry(attempt, next_delay, previous_error))
-    }
-}
-
-impl<E> BoxOnRetry<E> {
-    pub(crate) fn new<T>(inner: T) -> Self
-    where
-        T: OnRetry<E> + Send + Sync + 'static,
-        T::Future: Send + Sync + 'static,
-    {
-        Self {
-            inner: Arc::new(BoxOnRetryFuture(inner)),
-        }
-    }
-}
-
-impl<E> OnRetry<E> for BoxOnRetry<E> {
-    type Future = BoxFuture<'static, ()>;
-
-    fn on_retry(
-        &self,
-        attempt: u32,
-        next_delay: Option<Duration>,
-        previous_error: &E,
-    ) -> Self::Future {
-        self.inner.on_retry(attempt, next_delay, previous_error)
     }
 }


### PR DESCRIPTION
The purpose of `RetryFutureConfig` is to retry multiple futures in the same way,
without repeating yourself.

However sharing a `RetryFutureConfig` would often require naming its type to for
example return it from a function. If you were using a custom "on retry"
callback that would often be impossible as the callback was required to be a
function/closure.

This changes that so the "on retry" callback can be any type that implements
`OnRetry`. So to created a `RetryFutureConfig` with a custom callback can be
done by creating a struct:

Example usage:

```rust
#[derive(Clone)]
struct MyOnRetry;

impl OnRetry<std::io::Error> for MyOnRetry {
    type Future = futures::future::BoxFuture<'static, ()>;

    fn on_retry(
        &mut self,
        attempt: u32,
        next_delay: Option<Duration>,
        previous_error: &std::io::Error,
    ) -> Self::Future {
        Box::pin(async move {
            // do something!
        })
    }
}

let config: RetryFutureConfig<LinearBackoff, MyOnRetry> = RetryFutureConfig::new(10)
    .linear_backoff(Duration::from_millis(100))
    .on_retry(MyOnRetry);
```

This can then be returned from functions or put in a `once_cell::sync::Lazy` for
sharing the config.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below