### PR TITLE
Drop Display trait bound on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Changed
-- N/A
+- `RetryFuture` no longer requires the error type to implement `Drop`.
 
 ### Deprecated
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Changed
-- `RetryFuture` no longer requires the error type to implement `Drop`.
+- `RetryFuture` no longer requires the error type to implement `Display`.
 
 ### Deprecated
 - N/A

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,6 @@ impl<F, Fut, B, T, E, OnRetryT> Future for RetryFuture<F, Fut, B, OnRetryT>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, E>>,
-    E: fmt::Display,
     B: BackoffStrategy<E>,
     B::Output: Into<RetryPolicy>,
     OnRetryT: OnRetry<E>,


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Remove the `F::Error: Display` bound from the `Future` impl on `RetryFuture`.

It's never used anyway (any such bound should be decided by the `on_retry` future, not `RetryFuture` itself), and it's a papercut for experimenting with the library.