### PR TITLE
Fix type inference for `on_retry`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,10 @@ where
     /// # }
     /// ```
     #[inline]
-    pub fn on_retry<F>(self, f: F) -> RetryFuture<MakeFutureT, FutureT, BackoffT, F> {
+    pub fn on_retry<F, OnRetryFut>(self, f: F) -> RetryFuture<MakeFutureT, FutureT, BackoffT, F>
+    where
+        F: for<'a> Fn(u32, Option<Duration>, &E) -> OnRetryFut,
+    {
         RetryFuture {
             make_future: self.make_future,
             attempts_remaining: self.attempts_remaining,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ where
     #[inline]
     pub fn on_retry<F, OnRetryFut>(self, f: F) -> RetryFuture<MakeFutureT, FutureT, BackoffT, F>
     where
-        F: for<'a> Fn(u32, Option<Duration>, &E) -> OnRetryFut,
+        F: Fn(u32, Option<Duration>, &E) -> OnRetryFut,
     {
         RetryFuture {
             make_future: self.make_future,
@@ -883,5 +883,16 @@ mod tests {
             .with_config(config)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn inference_works() {
+        // See https://github.com/EmbarkStudios/tryhard/issues/20 for details.
+        let _ = async {
+            let _ = retry_fn(|| async { Result::<_, Infallible>::Ok(()) })
+                .retries(0)
+                .on_retry(|_, _, _| async {})
+                .await;
+        };
     }
 }


### PR DESCRIPTION
Had a stab at #20. 

Still a bit hazy on why this change is needed but it fixes the problem afaict. Insipration came from reading through https://github.com/rust-lang/rust/issues/70263.

Q: what would a good way to test this be? Would a ui test be welcome, simply to prove that the code sample in #20 compiles?

Closes #20

