### PR TITLE
Use `saturating_mul` instead of `Mul`

### DIFF
--- a/src/backoff_strategies.rs
+++ b/src/backoff_strategies.rs
@@ -51,7 +51,7 @@ impl<'a, E> BackoffStrategy<'a, E> for ExponentialBackoff {
     #[inline]
     fn delay(&mut self, _attempt: u32, _error: &'a E) -> Duration {
         let prev_delay = self.delay;
-        self.delay *= 2;
+        self.delay = self.delay.saturating_mul(2);
         prev_delay
     }
 }
@@ -100,7 +100,7 @@ impl<'a, E> BackoffStrategy<'a, E> for LinearBackoff {
 
     #[inline]
     fn delay(&mut self, attempt: u32, _error: &'a E) -> Duration {
-        self.delay * attempt
+        self.delay.saturating_mul(attempt)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,11 +888,11 @@ mod tests {
     #[tokio::test]
     async fn inference_works() {
         // See https://github.com/EmbarkStudios/tryhard/issues/20 for details.
-        let _ = async {
+        std::mem::drop(async {
             let _ = retry_fn(|| async { Result::<_, Infallible>::Ok(()) })
                 .retries(0)
                 .on_retry(|_, _, _| async {})
                 .await;
-        };
+        });
     }
 }


### PR DESCRIPTION
Currently if the duration gets large enough from an outage the current code will panic killing the service entirely. This fixes that by using `saturating_mul` instead so it will just remain at the maximum possible duration.

fixes #24 