### PR TITLE
chore(deps): move futures to dev-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Changed
-- N/A
+- Moved the `futures` dependency to `dev-dependencies`. MSRV is now 1.48.
 
 ### Deprecated
 - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["rust-patterns"]
 keywords = ["tokio", "futures", "retry"]
 
 [dependencies]
-futures = "0.3"
 pin-project-lite = "0.2"
 
 [dependencies.tokio]
@@ -21,3 +20,6 @@ package = "tokio"
 version = "1"
 default-features = false
 features = ["rt", "time", "macros", "test-util", "sync"]
+
+[dev-dependencies]
+futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,6 @@
     clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
-    clippy::mismatched_target_os,
     clippy::needless_borrow,
     clippy::needless_continue,
     clippy::option_option,
@@ -175,6 +174,7 @@
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,
+    unexpected_cfgs,
     future_incompatible,
     nonstandard_style,
     rust_2018_idioms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@
 use backoff_strategies::{
     BackoffStrategy, ExponentialBackoff, FixedBackoff, LinearBackoff, NoBackoff,
 };
-use futures::ready;
 use pin_project_lite::pin_project;
 use std::time::Duration;
 use std::{
@@ -569,18 +568,19 @@ where
                     future: (this.make_future)(),
                 },
 
-                RetryStateProj::TimerActive { sleep } => {
-                    ready!(sleep.poll(cx));
-                    RetryState::WaitingForFuture {
+                RetryStateProj::TimerActive { sleep } => match sleep.poll(cx) {
+                    Poll::Ready(()) => RetryState::WaitingForFuture {
                         future: (this.make_future)(),
-                    }
-                }
+                    },
+                    Poll::Pending => return Poll::Pending,
+                },
 
-                RetryStateProj::WaitingForFuture { future } => match ready!(future.poll(cx)) {
-                    Ok(value) => {
+                RetryStateProj::WaitingForFuture { future } => match future.poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(value)) => {
                         return Poll::Ready(Ok(value));
                     }
-                    Err(error) => {
+                    Poll::Ready(Err(error)) => {
                         if *this.attempts_remaining == 0 {
                             if let Some(on_retry) = &mut this.config.on_retry {
                                 tokio::spawn(on_retry.on_retry(*this.attempt, None, &error));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ mod tests {
 
         // assertions about what the exact times are are very finicky so lets just assert that the
         // one without backoff is slower.
-        assert!(time_with_fixed > time_with_none);
+        assert!(time_with_fixed >= time_with_none);
     }
 
     // `RetryFuture` must be `Send` to be used with `async_trait`

--- a/src/on_retry.rs
+++ b/src/on_retry.rs
@@ -1,5 +1,8 @@
-use futures::future::Ready;
-use std::{convert::Infallible, future::Future, time::Duration};
+use std::{
+    convert::Infallible,
+    future::{Future, Ready},
+    time::Duration,
+};
 
 /// Trait allowing you to run some future when a retry occurs. Could for example to be used for
 /// logging or other kinds of telemetry.


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
The futures crate bring a whole async executor whereas the only things that are used in this lib are : 
* The `Future` trait which comes from the `̀futures-core` lib and also exist in the std lib (MSRV 1.36)
* The `Ready` struct which comes from the `futures-util` lib  and also exist in the std lib (MSRV 1.48)
* The `ready` macro which comes from the `futures-core` lib (and can be replaced with match statements).

Currently everything is either available in the std or can be replaced.

It might also be a good idea to define a msrv for this crate.

### Related Issues
 * https://github.com/nats-io/nats.rs/issues/1421
